### PR TITLE
minimal example for setting working dir.

### DIFF
--- a/examples/test_working_directory.ipynb
+++ b/examples/test_working_directory.ipynb
@@ -1,0 +1,29 @@
+{
+ "metadata": {
+  "name": "",
+  "signature": "sha256:3659a38a8083e6d979fb4fbf47bdace618575be6aadb67b9a8d9a2bce80990fe"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "\"\"\"test\"\"\"\n",
+      "import sys\n",
+      "import os\n",
+      "assert 'test_working_directory.ipynb' in os.listdir('.')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 14
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}


### PR DESCRIPTION
Set this up as a minimal example for issue #2. Put as pull request so I can update with any useful changes.

To illustrate the issue, run py.test from the root directory (test
should fail). Then, open the ipython notebook and run the test cell (the
assert statement should be true).

I think that py.test doesn't set working directory to the containing folder, so I suppose whether it's worth implementing depends on if we're taking the perspective of ipython notebooks or py.test. It would be convenient for testing notebooks when they're being used as examples, but I could see some value in keeping it consistent with py.test.